### PR TITLE
fix(wan): memory optimization and single-GPU distributed init

### DIFF
--- a/wan/generate.py
+++ b/wan/generate.py
@@ -13,7 +13,9 @@ from wan.inference.helper import (
     MyVAE,
     CHUNK_SIZE,
 )
-from hyvideo.generate import pose_string_to_json
+# Lazy import pose utilities to avoid hyvideo's parallel state init at module load
+# (hyvideo/generate.py calls initialize_parallel_state() at import time which
+# conflicts with WAN's own distributed init when running in single-GPU mode)
 from wan.inference.pipeline_wan_w_mem_relative_rope import WanPipeline
 from wan.models.dits.arwan_w_action_w_mem_relative_rope import WanTransformer3DModel
 from wan.distributed import (
@@ -86,47 +88,44 @@ class WanRunner:
         self.device = device
         torch.cuda.set_device(self.local_rank)
 
-        # Initialize distributed environment if world_size > 1
+        # Initialize distributed environment - needed even for single GPU
         # Setup distributed training for multi-process inference
-        if self.world_size > 1:
-            if not torch.distributed.is_initialized():
-                torch.distributed.init_process_group(backend="nccl")
+        if not torch.distributed.is_initialized():
+            torch.distributed.init_process_group(backend="nccl")
 
-            # Initialize model parallel with project's custom function
-            # Enable sequence parallelism across all GPUs
-            maybe_init_distributed_environment_and_model_parallel(
-                1,
-                sp_size=self.world_size,
-                distributed_init_method="env://",
-            )
+        # Initialize model parallel with project's custom function
+        # Enable sequence parallelism (sp_size=1 for single GPU)
+        maybe_init_distributed_environment_and_model_parallel(
+            1,
+            sp_size=self.world_size,
+            distributed_init_method="env://",
+        )
 
         # Initialize models
         self._init_models()
 
     def _init_models(self):
         # Load VAE for encoding/decoding video frames
+        # Use low_cpu_mem_usage to avoid loading entire model to RAM first
         self.vae = (
             MyVAE.from_pretrained(
-                self.model_id, subfolder="vae", torch_dtype=torch.bfloat16
+                self.model_id, subfolder="vae", torch_dtype=torch.bfloat16,
+                low_cpu_mem_usage=True, device_map=self.device
             )
             .eval()
             .requires_grad_(False)
         )
-        self.vae.to(self.device)
 
-        # Load main diffusion pipeline
+        # Load main diffusion pipeline - load directly to GPU
         self.pipe = WanPipeline.from_pretrained(
-            self.model_id, vae=self.vae, torch_dtype=torch.bfloat16
+            self.model_id, vae=self.vae, torch_dtype=torch.bfloat16,
+            low_cpu_mem_usage=True
         )
+        # Move pipeline to GPU immediately after loading each component
+        self.pipe.to(self.device)
 
-        # Create distributed VAE wrapper for multi-GPU decoding
-        dist_vae = (
-            MyVAE.from_pretrained(
-                self.model_id, subfolder="vae", torch_dtype=torch.bfloat16
-            )
-            .eval()
-            .requires_grad_(False)
-        ).to(self.device)
+        # Reuse the same VAE for distributed wrapper instead of loading another copy
+        dist_vae = self.vae
         vae_chunk_dim = 4  # chunk width dim for vae input
         # Setup VAE for context-parallel decoding across GPUs
         dist_controller = DistController(
@@ -136,17 +135,22 @@ class WanRunner:
         self.pipe.dist_vae = dist_vae
 
         # Load autoregressive transformer with action conditioning
+        # Use low_cpu_mem_usage to load directly to GPU piece by piece
         transformer_ar_action = WanTransformer3DModel.from_pretrained(
             self.ar_model_path,
             use_safetensors=True,
             local_files_only=True,
+            low_cpu_mem_usage=True,
+            device_map=self.device,
+            torch_dtype=torch.bfloat16,
         )
         # Add action parameters to enable camera control
         transformer_ar_action.add_discrete_action_parameters()
 
         # Load trained checkpoint weights
+        # Load directly to GPU to avoid OOM on systems with limited RAM
         state_dict = torch.load(
-            self.ckpt_path, map_location=lambda storage, loc: storage
+            self.ckpt_path, map_location=self.device
         )
 
         state_dict = state_dict["generator"]
@@ -165,9 +169,10 @@ class WanRunner:
         }
 
         transformer_ar_action.load_state_dict(state_dict, strict=True)
-        self.pipe.transformer = transformer_ar_action.to(torch.bfloat16)
+        # Transformer already on GPU from device_map, just ensure dtype
+        self.pipe.transformer = transformer_ar_action.to(dtype=torch.bfloat16)
+        # Ensure entire pipeline is on GPU
         self.pipe.to(self.device)
-        self.pipe.transformer.to(torch.bfloat16)
 
     def predict(self, input_dict):
         prompt = input_dict.get("prompt", "")
@@ -193,7 +198,7 @@ class WanRunner:
             width=width,
             num_frames=num_frames,
             num_inference_steps=num_inference_steps,
-            guidance_scale=1,
+            guidance_scale=5.0,  # Higher = more prompt adherence + dynamics
             few_step=True,
             first_chunk_size=CHUNK_SIZE,
             return_dict=False,
@@ -202,12 +207,12 @@ class WanRunner:
             context_window_length=context_window_length,
         )
 
-        # Convert pose string to pose json using hyvideo's function
+        # Convert pose string to pose json
+        # Lazy import to avoid hyvideo's parallel state init at module load time
+        # (by this point, WAN's distributed init has already completed)
+        from hyvideo.generate import pose_string_to_json, pose_to_input
+        
         pose_json = pose_string_to_json(pose)
-
-        # Use helper to convert pose json to model inputs
-        from hyvideo.generate import pose_to_input
-
         all_viewmats, all_Ks, all_action = pose_to_input(pose_json, len(pose_json))
 
         all_save = []
@@ -444,6 +449,7 @@ if __name__ == "__main__":
                     print("Generate time:", time.time() - start_time)
 
             except Exception as e:
+                import traceback
                 if rank == 0:
                     error_msg = (
                         f"\n{'='*80}\n"
@@ -453,6 +459,7 @@ if __name__ == "__main__":
                         f"  Seed: {seed_idx}\n"
                         f"  Prompt: {input_data['prompt']}\n"
                         f"  Error: {str(e)}\n"
+                        f"  Traceback:\n{traceback.format_exc()}\n"
                         f"{'='*80}\n"
                     )
                     print(error_msg)


### PR DESCRIPTION
This patch fixes several issues in wan/generate.py that caused crashes and poor output quality when running on single-GPU systems.

## Fixes

### 1. Distributed Init for Single GPU
The original code only initialized distributed environment when world_size > 1, but the model parallel group is required even for single-GPU inference. This caused:
  "Error: sequence model parallel group is not initialized"

### 2. Memory Optimizations (OOM Prevention)
- Added `low_cpu_mem_usage=True` to all from_pretrained() calls
- Added `device_map=self.device` to load models directly to GPU
- Changed `torch.load(map_location=lambda...)` to `map_location=device`
- Reuse VAE instance instead of loading it twice for dist_vae

These changes prevent OOM crashes on systems with limited RAM by avoiding the pattern of loading entire models to CPU then moving to GPU.

### 3. Guidance Scale Fix
Changed `guidance_scale=1` to `guidance_scale=5.0`. The original value of 1 effectively disabled prompt guidance, causing generated videos to have frozen/static elements (fire not flickering, smoke not moving, etc.). The pipeline default is 5.0.

### 4. Lazy Import of pose_string_to_json
Moved import of pose_string_to_json and pose_to_input from module level to inside predict(). The hyvideo.generate module runs initialize_parallel_state() at import time, which conflicts with WAN's own distributed init when running after WAN has already initialized.

### 5. Better Error Reporting
Added traceback.format_exc() to error messages for easier debugging.

## Testing
Tested on single NVIDIA GPU with:
- Simple pose strings: `w-7`, `left-5,w-10`
- Various prompts with dynamic elements
- Memory usage reduced, no OOM crashes